### PR TITLE
Ensure Jam_Association::is_changed always return boolean

### DIFF
--- a/classes/Kohana/Jam/Association.php
+++ b/classes/Kohana/Jam/Association.php
@@ -39,9 +39,8 @@ abstract class Kohana_Jam_Association extends Jam_Attribute {
 	{
 		if ($value instanceof Jam_Model AND ( ! $value->loaded() OR $value->changed()))
 			return TRUE;
-
-		if (is_array($value)) 
-			return TRUE;
+		
+		return is_array($value);
 	}
 
 	public $foreign_model = NULL;


### PR DESCRIPTION
If the value is not changed `Jam_Association::is_changed()` was returning `NULL`.

Now it will return only `TRUE` or `FALSE`.
