### PR TITLE
Jam_Errors::message() now uses i18n for error messages; fixes #16

### DIFF
--- a/classes/Kohana/Jam/Errors.php
+++ b/classes/Kohana/Jam/Errors.php
@@ -25,7 +25,7 @@ abstract class Kohana_Jam_Errors implements Countable, SeekableIterator, ArrayAc
 			return $error_filename.":{$attribute}.{$error}";
 		}
 
-		return strtr($message, $params);
+		return __($message, $params);
 	}
 
 	public static function attribute_label(Jam_Meta $meta, $attribute_name)


### PR DESCRIPTION
Fix for #16 
