### PR TITLE
Fixed stream upload error. Removed unused Upload_Source::process_type_stream()

### DIFF
--- a/classes/Kohana/Upload/Source.php
+++ b/classes/Kohana/Upload/Source.php
@@ -82,7 +82,7 @@ abstract class Kohana_Upload_Source {
 	{
 		$this->_data = $data;
 
-		if ($type = Upload_Source::guess_type($data))
+		if (($type = Upload_Source::guess_type($data)))
 		{
 			$this->_type = $type;
 		}
@@ -142,26 +142,6 @@ abstract class Kohana_Upload_Source {
 			throw new Kohana_Exception('There was an error moving the file to :directory', array(':directory' => $directory));
 
 		return $data['name'];
-	}
-
-	/**
-	 * Move the contents of the stream to a specified directory with a given name
-	 * @param  string $stream    
-	 * @param  string $directory 
-	 * @param  string $filename  
-	 */
-	public static function process_type_stream($stream, $directory, $filename)
-	{
-		$stream_handle = fopen($stream, "r");
-		$result_handle = fopen(Upload_Util::combine($directory, $filename), 'w');
-
-		$transfered_bytes = stream_copy_to_stream($stream_handle,  $result_handle);
-		
-		if ((int) $transfered_bytes <= 0)
-			throw new Kohana_Exception('No data (:t) was transfered from :stream to :directory ', array(':stream' => $stream, ':directory' => $directory));
-
-		fclose($stream_handle);
-		fclose($result_handle);
 	}
 
 	/**

--- a/classes/Kohana/Upload/Util.php
+++ b/classes/Kohana/Upload/Util.php
@@ -76,8 +76,8 @@ class Kohana_Upload_Util {
 
 		$transfered_bytes = stream_copy_to_stream($stream_handle,  $result_handle);
 		
-		if ((int) $transfered_bytes <= 0)
-			throw new Kohana_Exception('No data (:t) was transfered from :stream to :file ', array(':stream' => $stream, ':file' => $file));
+		if ( (int) $transfered_bytes <= 0)
+			throw new Kohana_Exception('No data was transfered from :stream to :file ', array(':stream' => $stream, ':file' => Debug::path($file)));
 
 		fclose($stream_handle);
 		fclose($result_handle);

--- a/tests/tests/upload/SourceTest.php
+++ b/tests/tests/upload/SourceTest.php
@@ -79,18 +79,4 @@ class Jam_Upload_SourceTest extends Testcase_Validate_Upload {
 
 		Upload_Source::process_type_upload($data, $this->test_local);
 	}
-
-	public function test_process_type_stream()
-	{
-		$file = $this->test_local.'file_stream_source.txt';
-		file_put_contents($file, 'test data');
-
-		Upload_Source::process_type_stream($file, $this->test_local2, 'file_stream_copy.txt');
-
-		$this->assertFileExists($this->test_local2.'file_stream_copy.txt');
-		$this->assertFileEquals($file, $this->test_local2.'file_stream_copy.txt');
-
-		unlink($file);
-		unlink($this->test_local2.'file_stream_copy.txt');
-	}
 }


### PR DESCRIPTION
`Upload_Source::process_type_stream()` was left behind when extracting `Upload_Util`, but it is used nowhere.

When specifying a path in the exception message, the absolute path on the server MUST not be revealed. That's what `Debug::path()` is for.

Also "(:t)" placeholder was left behind, but never used.
