### PR TITLE
Jam_Behavior_Uploadable now pass delete_file option to Jam_Field_Upload

### DIFF
--- a/classes/Kohana/Jam/Behavior/Uploadable.php
+++ b/classes/Kohana/Jam/Behavior/Uploadable.php
@@ -17,6 +17,7 @@ abstract class Kohana_Jam_Behavior_Uploadable extends Jam_Behavior
 	public $_save_size = FALSE;
 	public $_path = NULL;
 	public $_dynamic_server = NULL;
+	public $_delete_file = TRUE;
 
 	public function initialize(Jam_Meta $meta, $name) 
 	{			
@@ -42,7 +43,8 @@ abstract class Kohana_Jam_Behavior_Uploadable extends Jam_Behavior
 			'transformations' => $this->_transformations, 
 			'server' => $this->_server, 
 			'dynamic_server' => $this->_dynamic_server,
-			'save_size' => $this->_save_size
+			'save_size' => $this->_save_size,
+			'delete_file' => $this->_delete_file
 		)));	
 	}
 


### PR DESCRIPTION
Similar to other options for `Jam_Field_Upload`, `delete_file` should also
be passed from `Jam_Behavior_Uploadable` to the field.
