### PR TITLE
Overhaul of Jam_Query_Builder_Insert. Fixes #31

### DIFF
--- a/classes/Kohana/Jam.php
+++ b/classes/Kohana/Jam.php
@@ -382,9 +382,9 @@ abstract class Kohana_Jam {
 	 * @param  string $model 
 	 * @return Jam_Query_Builder_Insert
 	 */
-	public static function insert($model)
+	public static function insert($model, array $columns = array())
 	{
-		return new Jam_Query_Builder_Insert($model);
+		return Jam_Query_Builder_Insert::factory($model, $columns);
 	}
 
 	/**

--- a/guide/jam/builder.md
+++ b/guide/jam/builder.md
@@ -452,7 +452,7 @@ Jam::all('client')->where('client.title', '=', 'Patrik')->count_with_subquery();
 
 ## Update queries
 
-You can perform update queries with Jam::update() query builder. It has most of the select methods and some methods for updating rows.
+You can perform update queries with `Jam::update()` query builder. It has most of the select methods and some methods for updating rows.
 
 * where_key()
 * where()
@@ -494,7 +494,7 @@ Jam::update('client')->where('client.title', '=', 'Patrik')->value('title', 'Mav
 
 ## Insert queries
 
-You can perform insert queries with Jam::insert() query builder. It has most of the select methods and some methods for inserting rows.
+You can perform insert queries with `Jam::insert()` query builder. It has most of the select methods and some methods for inserting rows.
 
 * where_key()
 * where()
@@ -509,31 +509,80 @@ You can perform insert queries with Jam::insert() query builder. It has most of 
 * distinct()
 * order_by()
 * limit()
-* set()
-* value()
 
 ### Inserting a single record
 
-You can use `set()` for multiple column => value pairs or `value()` for a single 'key', 'value' pair.
+Just like you would do with Kohana database query builder.
+With Jam though you would pass the name of the model and get automatic field name resolving.
 
 ```php
 <?php
-Jam::insert('client')->set(array('client.title' => 'Patrik', 'username' => 'patrik76'))->execute()
-// INSERT INTO clients SET title = 'Patrik', username = 'patrik76'
+Jam::insert('client')
+	->columns(array(
+		'client.title',
+		'username' => 'patrick76'
+	))
+	->values(array(
+		'Patrik',
+		'patrik76'
+	))
+	->execute()
+// INSERT INTO clients VALUES (`title`, `username`) VALUES ("Patrik", "patrik76")
+?>
+```
+
+You could also pass columns as a second argument to `Jam::insert()`.
+
+```php
+<?php
+Jam::insert('client', array(
+	'client.title',
+	'username' => 'patrick76'
+))
+	->values(array(
+		'Patrik',
+		'patrik76'
+	))
+	->execute()
+// INSERT INTO clients VALUES (`title`, `username`) VALUES ('Patrik', 'patrik76')
+?>
+```
+
+You could pass any `Database_Query` (or `Database_Query_Builder`) instance to `values()`.
+This way you would insert values from a sub-query.
+
+```php
+<?php
+Jam::insert('client', array(
+	'client.title',
+	'username' => 'patrick76'
+))
+	->values(Jam::all('user')
+		->where('type', '=', 'client')
+		->select('name', 'username')
+		->limit(1))
+	->execute()
+// INSERT INTO clients VALUES (`title`, `username`) VALUES ('Patrik', 'patrik76')
 ?>
 ```
 
 ### Inserting multiple records
 
-You can also set them with `columns()` and `values()` methods. But there's a twist - you can insert multiple rows this way, if you pass multiple arrays to `values()`
+You can pass multiple arrays to `values()` to insert multiple rows.
 
 ```php
 <?php
-Jam::insert('client')->columns('title', 'username')->values(array('Patrik', 'patrick76'))->execute();
-// INSERT INTO clients(title, username) VALUES ('Patrik', 'patrik76');
 
 // Insert multiple rows
-Jam::insert('client')->columns('title', 'username')->values(array('Patrik', 'patrick76'), array('Martin', 'martin87'))->execute();
+Jam::insert('client', array('title', 'username'))
+	->values(array(
+		'Patrik',
+		'patrick76'
+	), array(
+		'Martin',
+		'martin87'
+	))
+	->execute();
 // INSERT INTO clients(title, username) VALUES ('Patrik', 'patrik76'), ('Martin', 'martin87');
 ?>
 ```
@@ -546,7 +595,7 @@ You can also perform INSERT ... SELECT queries with Jam_Builder. This is a bit m
 <?php
 Jam::insert('client')
 	->columns('title', 'username')
-	->select('order.name', 'order.id');
+	->select('order.name', 'order.id')
 	->from('order')
 	->where('order.price', '=', 1);
 // INSERT INTO clients(title, username) SELECT orders.name, orders.id FROM orders WHERE orders.price = 1;

--- a/tests/tests/CoreTest.php
+++ b/tests/tests/CoreTest.php
@@ -140,4 +140,24 @@ class Jam_CoreTest extends PHPUnit_Framework_TestCase {
 		$model = Jam::build_template('test_position', array('model' => 'test_position_big'));
 		$this->assertInstanceOf('Model_Test_Position_Big', $model);
 	}
+
+	/**
+	 * @covers Jam::insert
+	 */
+	public function test_insert()
+	{
+		$insert = Jam::insert('test_author');
+		$this->assertInstanceOf('Jam_Query_Builder_Insert' ,$insert);
+		$this->assertSame(Jam::meta('test_author'), $insert->meta());
+		$this->assertEquals(
+			'INSERT INTO `test_authors` () VALUES ',
+			$insert->compile()
+		);
+
+		$insert = Jam::insert('test_author', array('name', 'email'));
+		$this->assertEquals(
+			'INSERT INTO `test_authors` (`name`, `email`) VALUES ',
+			$insert->compile()
+		);
+	}
 }

--- a/tests/tests/query/builder/InsertTest.php
+++ b/tests/tests/query/builder/InsertTest.php
@@ -10,21 +10,265 @@
  */
 class Jam_Query_Builder_InsertTest extends PHPUnit_Framework_TestCase {
 
-	public function test_constructor()
+	/**
+	 * @covers Jam_Query_Builder_Insert::__construct
+	 */
+	public function test_constructs_model_to_table()
+	{
+		$insert = new Jam_Query_Builder_Insert('test_author');
+
+		$this->assertSame(
+			'INSERT INTO `test_authors` () VALUES ',
+			$insert->compile()
+		);
+	}
+
+	/**
+	 * @covers Jam_Query_Builder_Insert::__construct
+	 */
+	public function test_constructs_columns()
+	{
+		$insert = new Jam_Query_Builder_Insert('test_author', array(
+			'name',
+			'username'
+		));
+
+		$this->assertSame(
+			'INSERT INTO `test_authors` (`name`, `username`) VALUES ',
+			$insert->compile()
+		);
+	}
+
+	/**
+	 * @covers Jam_Query_Builder_Insert::__construct
+	 */
+	public function test_constructs_meta()
+	{
+		$insert = new Jam_Query_Builder_Insert('test_author');
+
+		$this->assertSame(Jam::meta('test_author'), $insert->meta());
+	}
+
+	/**
+	 * @covers Jam_Query_Builder_Insert::__construct
+	 */
+	public function test_event_builder_after_construct()
+	{
+		$mock = $this->getMock('stdClass', array(
+			'test_event_callback'
+		));
+
+		$jam_event_data_constraint = new PHPUnit_Framework_Constraint_And;
+
+		$jam_event_data_constraint
+			->setConstraints(array(
+				$this->isInstanceOf('Jam_Event_Data'),
+				$this->attribute($this->equalTo('builder.after_construct'), 'event'),
+				$this->attribute($this->isInstanceOf('Jam_Query_Builder_Insert'), 'sender'),
+				$this->attribute($this->equalTo(array()), 'args'),
+			));
+
+		$mock
+			->expects($this->once())
+			->method('test_event_callback')
+			->with(
+				$this
+					->isInstanceOf('Jam_Query_Builder_Insert'),
+				$jam_event_data_constraint
+			);
+
+		Jam::meta('test_author')
+			->events()
+				->bind('builder.after_construct', array(
+					$mock, 'test_event_callback'
+				));
+
+		new Jam_Query_Builder_Insert('test_author');
+	}
+
+	/**
+	 * @covers Jam_Query_Builder_Insert::__call
+	 */
+	public function test_call()
+	{
+		$mock = $this->getMock('stdClass', array(
+			'test_event_callback'
+		));
+
+		$jam_event_data_constraint = new PHPUnit_Framework_Constraint_And;
+
+		$jam_event_data_constraint
+			->setConstraints(array(
+				$this->isInstanceOf('Jam_Event_Data'),
+				$this->attribute($this->equalTo('builder.call_custom'), 'event'),
+				$this->attribute($this->isInstanceOf('Jam_Query_Builder_Insert'), 'sender'),
+				$this->attribute($this->equalTo(array('abc')), 'args'),
+			));
+
+		$mock
+			->expects($this->once())
+			->method('test_event_callback')
+			->with(
+				$this
+					->isInstanceOf('Jam_Query_Builder_Insert'),
+				$jam_event_data_constraint,
+				$this->equalTo('abc')
+			);
+
+		Jam::meta('test_author')
+			->events()
+				->bind('builder.call_custom', array(
+					$mock, 'test_event_callback'
+				));
+
+		$insert = new Jam_Query_Builder_Insert('test_author');
+
+		$insert->custom('abc');
+	}
+
+	/**
+	 * @covers Jam_Query_Builder_Insert::meta
+	 */
+	public function test_meta()
+	{
+		$insert = new Jam_Query_Builder_Insert('test_author');
+
+		$this->assertSame(Jam::meta('test_author'), $insert->meta());
+	}
+
+	/**
+	 * @covers Jam_Query_Builder_Insert::factory
+	 */
+	public function test_factory()
+	{
+		$insert = Jam_Query_Builder_Insert::factory('test_author', array('first_name', 'last_name'));
+
+		$this->assertInstanceOf('Jam_Query_Builder_Insert', $insert);
+		$this->assertSame(
+			'INSERT INTO `test_authors` (`first_name`, `last_name`) VALUES ',
+			$insert->compile()
+		);
+	}
+
+	/**
+	 * @covers Jam_Query_Builder_Insert::__toString
+	 */
+	public function test_toString()
+	{
+		$insert = $this->getMock('Jam_Query_Builder_Insert', array(
+			'compile'
+		), array(
+			'test_author'
+		));
+
+		$insert
+			->expects($this->once())
+			->method('compile')
+			->will($this->returnValue('ABCDE'));
+
+		$this->assertSame('ABCDE', $insert->__toString());
+	}
+
+	/**
+	 * @covers Jam_Query_Builder_Insert::__toString
+	 */
+	public function test_toString_exception()
+	{
+		$insert = $this->getMock('Jam_Query_Builder_Insert', array(
+			'compile'
+		), array(
+			'test_author'
+		));
+
+		$insert
+			->expects($this->once())
+			->method('compile')
+			->will($this->throwException(new Jam_Exception_Missing('test exception catching'))); $line = __LINE__;
+
+		$file = __FILE__;
+
+		$this->assertSame("Jam_Exception_Missing [ 0 ]: test exception catching ~ {$file} [ {$line} ]", $insert->__toString());
+	}
+
+	public function data_params_setting()
+	{
+		return array(
+			array(
+				'abc',
+				'xyz',
+				array('abc' => 'xyz'),
+			),
+			array(
+				array('qwe' => 'qwerty'),
+				'xyz',
+				array('qwe' => 'qwerty'),
+			),
+			array(
+				array('qwe' => 'qwerty'),
+				NULL,
+				array('qwe' => 'qwerty'),
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider data_params_setting
+	 * @covers Jam_Query_Builder_Insert::params
+	 */
+	public function test_params_setting($key, $value, $expected)
 	{
 		$insert = Jam_Query_Builder_Insert::factory('test_author');
 
-		$insert
-			->columns(array('name'));
+		$insert->params($key, $value);
 
-		$insert
-			->values(array('Test'));
+		$this->assertSame($expected, $insert->params());
+	}
 
-		$this->assertInstanceOf('Jam_Query_Builder_Insert', $insert);
+	public function data_params_getting()
+	{
+		return array(
+			array(
+				array('abc' => 'xyz'),
+				'abc',
+				'xyz',
+			),
+			array(
+				array('abc' => 'xyz'),
+				NULL,
+				array('abc' => 'xyz'),
+			),
+		);
+	}
 
-		$this->assertEquals(Jam::meta('test_author'), $insert->meta());
+	/**
+	 * @dataProvider data_params_getting
+	 * @covers Jam_Query_Builder_Insert::params
+	 */
+	public function test_params_getting($params, $key, $expected)
+	{
+		$insert = Jam_Query_Builder_Insert::factory('test_author');
 
-		$this->assertEquals('INSERT INTO `test_authors` (`name`) VALUES (\'Test\')', (string) $insert);
+		$insert->params($params);
+
+		$this->assertSame($expected, $insert->params($key));
+	}
+
+	/**
+	 * @covers Jam_Query_Builder_Insert::params
+	 */
+	public function test_params_merging()
+	{
+		$insert = Jam_Query_Builder_Insert::factory('test_author');
+		$insert->params(array('abc' => 'xyz'));
+		$insert->params('rt', 'qw');
+		$insert->params(array('abc' => 'uiop'));
+		$insert->params(array('zyx' => 'xyz'));
+
+		$this->assertSame(array(
+			'abc' => 'uiop',
+			'rt' => 'qw',
+			'zyx' => 'xyz'
+		), $insert->params());
 	}
 }
 	


### PR DESCRIPTION
In short this will:
- Change it to be more consistent with Database_Query_Builder_Insert.
- Fix small bugs in `params()` and `__call()`.
- Add real unit tests. `compile()` and `execute()` are still to be tested.
- Fix PHPDoc.
- Change `Jam::insert()` accordingly.
- Fix docs.

See the squashed commits below for more details.

commit a3fa684efb00b24070abfb3ae777fb59c572f647
Author: Haralan Dobrev hkdobrev@gmail.com
Date:   Sat Nov 9 20:32:49 2013 +0200

```
Fix docs for `Jam::insert()`

Basically the previous documentation for `Jam::insert()` was a shameless
copy of the documentation of `Jam::update`.
Wrong SQL examples like:
    INSERT INTO clients SET title = 'Patrik', username = 'patrik76'
are removed.

Added more/better examples for:
 * inserting a single record
 * using the columns argument
 * using a sub query
```

commit 87a410a229183c92e7b77ecdbd608c1c02926ac8
Author: Haralan Dobrev hkdobrev@gmail.com
Date:   Sat Nov 9 20:32:45 2013 +0200

```
Make `Jam::insert()` support columns
```

commit 5973a87698876774d4a8c5228790d8a2d58126b1
Author: Haralan Dobrev hkdobrev@gmail.com
Date:   Sat Nov 9 20:32:21 2013 +0200

```
Add unit tests for Jam_Query_Builder_Insert
```

commit c0a825558e8e366d4e46bd1f7277d0d14db1966f
Author: Haralan Dobrev hkdobrev@gmail.com
Date:   Sat Nov 9 20:31:15 2013 +0200

```
Improve PHPDoc for Jam_Query_Builder_Insert methods
```

commit 342063c2bdd75033c9b7c5d7e12539918ce78f9f
Author: Haralan Dobrev hkdobrev@gmail.com
Date:   Sat Nov 9 20:29:46 2013 +0200

```
Fix Jam_Query_Builder_Insert::__call()

When the called function return a non-NULL, evaluating-to-FALSE value,
it should be returned instead of $this.
Indented code to not go over 80 characters per line.
```

commit a591ffb9aeb2d99ee1cd00efa03cc7f8aaf3d7f9
Author: Haralan Dobrev hkdobrev@gmail.com
Date:   Sat Nov 9 20:26:48 2013 +0200

```
Fix Jam_Query_Builder_Insert::params()

* Merging of params should happen with a priority for the new params.
* When the first argument is an array and the second argument is not NULL,
an exception should not be thrown, but the second argument to be ignored instead.
* Code is cleaner by using recursion for the simpler (key, value) case.
```

commit 0f10d7519dac0d008ae82f8169f2247ef9e67544
Author: Haralan Dobrev hkdobrev@gmail.com
Date:   Sat Nov 9 20:18:40 2013 +0200

```
Allow passing columns to insert builder constructor

Allow passing a `$columns` array to `Jam_Query_Builder::__constructi()`
and respectively to `Jam_Query_Builder_Insert::factory()`.

Use `parent::__construct()` to set the table and the columns.

Notes:

The previous statement about the first argument is simply not true:
http://git.io/JOvVqA
> `$model` is not actually allowed to be NULL. It has
a default because PHP throws strict errors otherwise.

From PHP documentation:
http://php.net/manual/en/language.oop5.decon.php
> Unlike with other methods, PHP will **not** generate an E_STRICT level error
message when __construct() is overridden with different parameters than
the parent __construct() method has.
```
