### PR TITLE
Do not change the foreign key when setting string

### DIFF
--- a/classes/Kohana/Jam/Association.php
+++ b/classes/Kohana/Jam/Association.php
@@ -30,7 +30,10 @@ abstract class Kohana_Jam_Association extends Jam_Attribute {
 		if ($value instanceof Jam_Validated) 
 			return $value->id();
 
-		if (is_integer($value) OR is_string($value)) 
+		if (is_integer($value) OR is_numeric($value)) 
+			return (int) $value;
+
+		if (is_string($value))
 			return $value;
 
 		if (is_array($value)) 

--- a/tests/tests/AssociationTest.php
+++ b/tests/tests/AssociationTest.php
@@ -17,6 +17,9 @@ class Jam_AssociationTest extends PHPUnit_Framework_TestCase {
 		return array(
 			array('test_position', NULL, NULL),
 			array('test_position', 1, 1),
+			array('test_position', '1', 1),
+			array('test_position', '256', 256),
+			array('test_position', '256abc', '256abc'),
 			array('test_position', 'test', 'test'),
 			array('test_position', $test_position, 10),
 			array('test_position', array('id' => 10), 10),
@@ -25,11 +28,12 @@ class Jam_AssociationTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @covers Jam_Association::primary_key
 	 * @dataProvider data_primary_key
 	 */
 	public function test_primary_key($model_name, $value, $expected_primary_key)
 	{
-		$this->assertEquals($expected_primary_key, Jam_Association::primary_key($model_name, $value));
+		$this->assertSame($expected_primary_key, Jam_Association::primary_key($model_name, $value));
 	}
 
 	public function test_associated()

--- a/tests/tests/association/BelongsToTest.php
+++ b/tests/tests/association/BelongsToTest.php
@@ -350,4 +350,21 @@ class Jam_Association_BelongstoTest extends PHPUnit_Framework_TestCase {
 
 		$model->meta()->association('test_author')->model_before_save($model, new Jam_Event_Data(array()), $changed);
 	}
+
+	/**
+	 * Test foreign key is not changed when association is updated
+	 * with the same value, but with string type.
+	 *
+	 * @coversNothing
+	 */
+	public function test_foreign_key_not_changed_with_string()
+	{
+		$test_post = Jam::build('test_post')
+			->load_fields(array(
+				'test_blog_id' => 5
+			));
+
+		$test_post->test_blog = '5';
+		$this->assertFalse($test_post->changed('test_blog_id'));
+	}
 }


### PR DESCRIPTION
When you have a `belongsto` association and you set a numeric string directly to the association key the foreign key is changed, because of the strict check for fields. (See #39)

Example:

```
$post->blog = "5";
$post->changed("blog_id"); // returns TRUE
```

Normally you would not assign a string for an integer foreign key, but when you submit forms this is what happens.

```
<input type="hidden" name="blog" value="5"/>
```

I have added tests for this use case and updated the unit tests for `Jam_Association::primary_key()`.
