### PR TITLE
Allow to change model name for polymorphic queries

### DIFF
--- a/classes/Kohana/Jam/Association/Hasmany.php
+++ b/classes/Kohana/Jam/Association/Hasmany.php
@@ -99,7 +99,7 @@ abstract class Kohana_Jam_Association_Hasmany extends Jam_Association_Collection
 
 		if ($this->is_polymorphic())
 		{
-			$collection->where($this->polymorphic_key, '=', $model->meta()->model());
+			$collection->where($this->polymorphic_key, '=', $this->model);
 		}
 
 		return $collection;
@@ -119,7 +119,7 @@ abstract class Kohana_Jam_Association_Hasmany extends Jam_Association_Collection
 			{
 				if ($item instanceof Jam_Model)
 				{
-					$this->assign_item($item, $model->id(), $model->meta()->model(), $model);
+					$this->assign_item($item, $model->id(), $this->model, $model);
 				}
 			}
 		}
@@ -179,7 +179,7 @@ abstract class Kohana_Jam_Association_Hasmany extends Jam_Association_Collection
 
 		if ($this->is_polymorphic())
 		{
-			$query->where($this->polymorphic_key, '=', $model->meta()->model());
+			$query->where($this->polymorphic_key, '=', $this->model);
 		}
 
 		return $query;
@@ -199,7 +199,7 @@ abstract class Kohana_Jam_Association_Hasmany extends Jam_Association_Collection
 		if ($this->is_polymorphic())
 		{
 			$query
-				->where($this->polymorphic_key, '=', $model->meta()->model())
+				->where($this->polymorphic_key, '=', $this->model)
 				->value($this->polymorphic_key, NULL);
 		}
 		return $query;
@@ -262,7 +262,7 @@ abstract class Kohana_Jam_Association_Hasmany extends Jam_Association_Collection
 
 		if ($this->is_polymorphic())
 		{
-			$query->value($this->polymorphic_key, $model->meta()->model());
+			$query->value($this->polymorphic_key, $this->model);
 		}
 		return $query;
 	}
@@ -297,7 +297,7 @@ abstract class Kohana_Jam_Association_Hasmany extends Jam_Association_Collection
 	 */
 	public function item_get(Jam_Model $model, Jam_Model $item)
 	{
-		$this->assign_item($item, $model->id(), $model->meta()->model(), $model);
+		$this->assign_item($item, $model->id(), $this->model, $model);
 	}
 
 	/**
@@ -308,7 +308,7 @@ abstract class Kohana_Jam_Association_Hasmany extends Jam_Association_Collection
 	 */
 	public function item_set(Jam_Model $model, Jam_Model $item)
 	{
-		$this->assign_item($item, $model->id(), $model->meta()->model(), $model);
+		$this->assign_item($item, $model->id(), $this->model, $model);
 	}
 
 	/**

--- a/classes/Kohana/Jam/Attribute.php
+++ b/classes/Kohana/Jam/Attribute.php
@@ -63,7 +63,9 @@ abstract class Kohana_Jam_Attribute {
 	public function initialize(Jam_Meta $meta, $name)
 	{
 		// This will come in handy for setting complex relationships
-		$this->model = $meta->model();
+		if (!$this->model) {
+			$this->model = $meta->model();
+		}
 
 		// This is for naming form fields
 		$this->name = $name;


### PR DESCRIPTION
The `hasmany` association always use the name of the model as the value against
the `polymorphic_key`.

When using STI (single-table inheritance) you might want to always use the parent model.

This change allows just that.
