### PR TITLE
Error message for max file upload size

### DIFF
--- a/classes/Kohana/Upload/Source.php
+++ b/classes/Kohana/Upload/Source.php
@@ -143,7 +143,7 @@ abstract class Kohana_Upload_Source {
 		{
 			$errors = array(
 				UPLOAD_ERR_OK          => 'No errors.',
-				UPLOAD_ERR_INI_SIZE    => 'must not be larger than '.ini_get('post_max_size'),
+				UPLOAD_ERR_INI_SIZE    => 'must not be larger than '.ini_get('upload_max_filesize'),
 				UPLOAD_ERR_FORM_SIZE   => 'must not be larger than specified',
 				UPLOAD_ERR_PARTIAL     => 'was only partially uploaded.',
 				UPLOAD_ERR_NO_FILE     => 'no file was uploaded.',

--- a/tests/tests/upload/SourceTest.php
+++ b/tests/tests/upload/SourceTest.php
@@ -41,7 +41,7 @@ class Jam_Upload_SourceTest extends Testcase_Validate_Upload {
 		return array(
 			array(
 				UPLOAD_ERR_INI_SIZE,
-				'File not uploaded properly. Error: must not be larger than '.ini_get('post_max_size')
+				'File not uploaded properly. Error: must not be larger than '.ini_get('upload_max_filesize')
 			),
 			array(
 				UPLOAD_ERR_PARTIAL,


### PR DESCRIPTION
UPLOAD_ERR_INI_SIZE - The uploaded file exceeds the upload_max_filesize directive in php.ini
http://php.net/manual/en/features.file-upload.errors.php
