### PR TITLE
Use PHPunit DOM assertions instead of deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
 		"openbuildings/flex-storage": "0.1.*"
 	},
 	"require-dev": {
-		"openbuildings/kohana-test-bootsrap": "0.1.*"
+		"openbuildings/kohana-test-bootsrap": "0.1.*",
+		"phpunit/phpunit-dom-assertions": "1.0.*@dev"
 	},
 	"suggest": {
 		"openbuildings/jam-auth": "A Kohana Auth implementation for Jam, with services",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "f1381888121e85496e31c171b03b063a",
+    "hash": "5941b4bb87bababefc3e03fbb55914a7",
     "packages": [
         {
             "name": "composer/installers",
@@ -181,6 +181,119 @@
     ],
     "packages-dev": [
         {
+            "name": "ocramius/instantiator",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Ocramius/Instantiator.git",
+                "reference": "e24a12178906ff2e7471b8aaf3a0eb789b59f881"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Ocramius/Instantiator/zipball/e24a12178906ff2e7471b8aaf3a0eb789b59f881",
+                "reference": "e24a12178906ff2e7471b8aaf3a0eb789b59f881",
+                "shasum": ""
+            },
+            "require": {
+                "ocramius/lazy-map": "1.0.*",
+                "php": "~5.3"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1.8",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "2.0.*@ALPHA"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Instantiator\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://github.com/Ocramius/Instantiator",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "time": "2014-08-25 14:48:16"
+        },
+        {
+            "name": "ocramius/lazy-map",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Ocramius/LazyMap.git",
+                "reference": "7fe3d347f5e618bcea7d39345ff83f3651d8b752"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Ocramius/LazyMap/zipball/7fe3d347f5e618bcea7d39345ff83f3651d8b752",
+                "reference": "7fe3d347f5e618bcea7d39345ff83f3651d8b752",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1.6",
+                "phpmd/phpmd": "1.5.*",
+                "phpunit/phpunit": ">=3.7",
+                "satooshi/php-coveralls": "~0.6",
+                "squizlabs/php_codesniffer": "1.4.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "LazyMap\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A library that provides lazy instantiation logic for a map of objects",
+            "homepage": "https://github.com/Ocramius/LazyMap",
+            "keywords": [
+                "lazy",
+                "lazy instantiation",
+                "lazy loading",
+                "map",
+                "service location"
+            ],
+            "time": "2013-11-09 22:30:54"
+        },
+        {
             "name": "openbuildings/kohana-test-bootsrap",
             "version": "0.1.2",
             "source": {
@@ -214,19 +327,868 @@
             ],
             "description": "Kohana core classes repackaged with composer, used to test modules",
             "time": "2013-10-01 08:57:54"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "2.0.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "53603b3c995f5aab6b59c8e08c3a663d2cc810b7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/53603b3c995f5aab6b59c8e08c3a663d2cc810b7",
+                "reference": "53603b3c995f5aab6b59c8e08c3a663d2cc810b7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "phpunit/php-file-iterator": "~1.3",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-token-stream": "~1.3",
+                "sebastian/environment": "~1.0",
+                "sebastian/version": "~1.0"
+            },
+            "require-dev": {
+                "ext-xdebug": ">=2.1.4",
+                "phpunit/phpunit": "~4.1"
+            },
+            "suggest": {
+                "ext-dom": "*",
+                "ext-xdebug": ">=2.2.1",
+                "ext-xmlwriter": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "time": "2014-08-31 06:33:04"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "1.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "acd690379117b042d1c8af1fafd61bde001bf6bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/acd690379117b042d1c8af1fafd61bde001bf6bb",
+                "reference": "acd690379117b042d1c8af1fafd61bde001bf6bb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "File/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "time": "2013-10-10 15:34:57"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "206dfefc0ffe9cebf65c413e3d0e809c82fbf00a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/206dfefc0ffe9cebf65c413e3d0e809c82fbf00a",
+                "reference": "206dfefc0ffe9cebf65c413e3d0e809c82fbf00a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "Text/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "time": "2014-01-30 17:20:04"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "19689d4354b295ee3d8c54b4f42c3efb69cbc17c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/19689d4354b295ee3d8c54b4f42c3efb69cbc17c",
+                "reference": "19689d4354b295ee3d8c54b4f42c3efb69cbc17c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "PHP/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "time": "2013-08-02 07:42:54"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "f8d5d08c56de5cfd592b3340424a81733259a876"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/f8d5d08c56de5cfd592b3340424a81733259a876",
+                "reference": "f8d5d08c56de5cfd592b3340424a81733259a876",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "time": "2014-08-31 06:12:13"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "4.2.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "c28a790620fe30b049bb693be1ef9cd4e0fe906c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c28a790620fe30b049bb693be1ef9cd4e0fe906c",
+                "reference": "c28a790620fe30b049bb693be1ef9cd4e0fe906c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "php": ">=5.3.3",
+                "phpunit/php-code-coverage": "~2.0",
+                "phpunit/php-file-iterator": "~1.3.1",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-timer": "~1.0.2",
+                "phpunit/phpunit-mock-objects": "~2.2",
+                "sebastian/comparator": "~1.0",
+                "sebastian/diff": "~1.1",
+                "sebastian/environment": "~1.0",
+                "sebastian/exporter": "~1.0",
+                "sebastian/version": "~1.0",
+                "symfony/yaml": "~2.0"
+            },
+            "suggest": {
+                "phpunit/php-invoker": "~1.1"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "",
+                "../../symfony/yaml/"
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "http://www.phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "time": "2014-09-14 09:31:24"
+        },
+        {
+            "name": "phpunit/phpunit-dom-assertions",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpunit/phpunit-dom-assertions.git",
+                "reference": "4e43c66e35fb5e30a0eeb535c861455540c0d9fb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpunit/phpunit-dom-assertions/zipball/4e43c66e35fb5e30a0eeb535c861455540c0d9fb",
+                "reference": "4e43c66e35fb5e30a0eeb535c861455540c0d9fb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "phpunit/phpunit": "~4.0",
+                "symfony/css-selector": "~2.0",
+                "symfony/dom-crawler": "~2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "DOM assertions for PHPUnit",
+            "homepage": "http://github.com/phpunit/phpunit-dom-assertions",
+            "keywords": [
+                "Xpath",
+                "assertions",
+                "css",
+                "dom",
+                "phpunit",
+                "tests"
+            ],
+            "time": "2014-08-27 18:14:08"
+        },
+        {
+            "name": "phpunit/phpunit-mock-objects",
+            "version": "2.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
+                "reference": "b241b18d87a47093f20fae8b0ba40379b00bd53a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/b241b18d87a47093f20fae8b0ba40379b00bd53a",
+                "reference": "b241b18d87a47093f20fae8b0ba40379b00bd53a",
+                "shasum": ""
+            },
+            "require": {
+                "ocramius/instantiator": "~1.0",
+                "php": ">=5.3.3",
+                "phpunit/php-text-template": "~1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "suggest": {
+                "ext-soap": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Mock Object library for PHPUnit",
+            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
+            "keywords": [
+                "mock",
+                "xunit"
+            ],
+            "time": "2014-09-06 17:32:37"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "f7069ee51fa9fb6c038e16a9d0e3439f5449dcf2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/f7069ee51fa9fb6c038e16a9d0e3439f5449dcf2",
+                "reference": "f7069ee51fa9fb6c038e16a9d0e3439f5449dcf2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sebastian/diff": "~1.1",
+                "sebastian/exporter": "~1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "time": "2014-05-02 07:05:58"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "1e091702a5a38e6b4c1ba9ca816e3dd343df2e2d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/1e091702a5a38e6b4c1ba9ca816e3dd343df2e2d",
+                "reference": "1e091702a5a38e6b4c1ba9ca816e3dd343df2e2d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "http://www.github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2013-08-03 16:46:33"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "79517609ec01139cd7e9fded0dd7ce08c952ef6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/79517609ec01139cd7e9fded0dd7ce08c952ef6a",
+                "reference": "79517609ec01139cd7e9fded0dd7ce08c952ef6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.0.*@dev"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "time": "2014-02-18 16:17:19"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "1f9a98e6f5dfe0524cb8c6166f7c82f3e9ae1529"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/1f9a98e6f5dfe0524cb8c6166f7c82f3e9ae1529",
+                "reference": "1f9a98e6f5dfe0524cb8c6166f7c82f3e9ae1529",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.0.*@dev"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net",
+                    "role": "Lead"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "time": "2014-02-16 08:26:31"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "b6e1f0cf6b9e1ec409a0d3e2f2a5fb0998e36b43"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/b6e1f0cf6b9e1ec409a0d3e2f2a5fb0998e36b43",
+                "reference": "b6e1f0cf6b9e1ec409a0d3e2f2a5fb0998e36b43",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "time": "2014-03-07 15:35:33"
+        },
+        {
+            "name": "symfony/css-selector",
+            "version": "v2.5.4",
+            "target-dir": "Symfony/Component/CssSelector",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/CssSelector.git",
+                "reference": "143abf51b91e4517cde67d416bdf67a90cffa32d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/CssSelector/zipball/143abf51b91e4517cde67d416bdf67a90cffa32d",
+                "reference": "143abf51b91e4517cde67d416bdf67a90cffa32d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\CssSelector\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Jean-François Simon",
+                    "email": "jeanfrancois.simon@sensiolabs.com"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony CssSelector Component",
+            "homepage": "http://symfony.com",
+            "time": "2014-08-31 03:22:04"
+        },
+        {
+            "name": "symfony/dom-crawler",
+            "version": "v2.5.4",
+            "target-dir": "Symfony/Component/DomCrawler",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/DomCrawler.git",
+                "reference": "27499e5951ef3d5731efe4db7481f26a68d75258"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/DomCrawler/zipball/27499e5951ef3d5731efe4db7481f26a68d75258",
+                "reference": "27499e5951ef3d5731efe4db7481f26a68d75258",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "symfony/css-selector": "~2.0"
+            },
+            "suggest": {
+                "symfony/css-selector": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\DomCrawler\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony DomCrawler Component",
+            "homepage": "http://symfony.com",
+            "time": "2014-08-26 14:16:33"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v2.5.4",
+            "target-dir": "Symfony/Component/Yaml",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Yaml.git",
+                "reference": "01a7695bcfb013d0a15c6757e15aae120342986f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/01a7695bcfb013d0a15c6757e15aae120342986f",
+                "reference": "01a7695bcfb013d0a15c6757e15aae120342986f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Yaml\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "http://symfony.com",
+            "time": "2014-08-31 03:22:04"
         }
     ],
-    "aliases": [
-
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [
-
-    ],
+    "stability-flags": {
+        "phpunit/phpunit-dom-assertions": 20
+    },
+    "prefer-stable": false,
     "platform": {
         "php": ">=5.3.0"
     },
-    "platform-dev": [
-
-    ]
+    "platform-dev": []
 }

--- a/tests/classes/Testcase/Database.php
+++ b/tests/classes/Testcase/Database.php
@@ -1,6 +1,6 @@
 <?php defined('SYSPATH') OR die('No direct script access.');
 
-abstract class Testcase_Database extends PHPUnit_Framework_TestCase {
+abstract class Testcase_Database extends PHPUnit_Framework_DOMTestCase {
 
 	public function setUp()
 	{

--- a/tests/classes/Testcase/Validate.php
+++ b/tests/classes/Testcase/Validate.php
@@ -1,6 +1,6 @@
 <?php defined('SYSPATH') OR die('No direct script access.');
 
-abstract class Testcase_Validate extends PHPUnit_Framework_TestCase {
+abstract class Testcase_Validate extends PHPUnit_Framework_DOMTestCase {
 
 	public function assertHasError($model, $attribute, $error)
 	{

--- a/tests/tests/ArrayTest.php
+++ b/tests/tests/ArrayTest.php
@@ -8,7 +8,7 @@
  * @group   jam.array
  * @group   jam.array.core
  */
-class Jam_ArrayTest extends PHPUnit_Framework_TestCase {
+class Jam_ArrayTest extends PHPUnit_Framework_DOMTestCase {
 
 	public function test_content_not_set()
 	{

--- a/tests/tests/AssociationTest.php
+++ b/tests/tests/AssociationTest.php
@@ -8,7 +8,7 @@
  * @group   jam.association
  * @group   jam.association.core
  */
-class Jam_AssociationTest extends PHPUnit_Framework_TestCase {
+class Jam_AssociationTest extends PHPUnit_Framework_DOMTestCase {
 
 	public function data_primary_key()
 	{

--- a/tests/tests/CoreTest.php
+++ b/tests/tests/CoreTest.php
@@ -7,7 +7,7 @@
  * @group   jam
  * @group   jam.core
  */
-class Jam_CoreTest extends PHPUnit_Framework_TestCase {
+class Jam_CoreTest extends PHPUnit_Framework_DOMTestCase {
 
 	/**
 	 * Provides for test_register

--- a/tests/tests/CountcacheTest.php
+++ b/tests/tests/CountcacheTest.php
@@ -5,7 +5,7 @@
  * @group   jam
  * @group   jam.countcache
  */
-class Jam_CountercacheTest extends PHPUnit_Framework_TestCase {
+class Jam_CountercacheTest extends PHPUnit_Framework_DOMTestCase {
 
 	public function data_update_counters()
 	{

--- a/tests/tests/EventTest.php
+++ b/tests/tests/EventTest.php
@@ -7,7 +7,7 @@
  * @group   jam
  * @group   jam.event
  */
-class Jam_EventTest extends PHPUnit_Framework_TestCase {
+class Jam_EventTest extends PHPUnit_Framework_DOMTestCase {
 
 	public $event;
 

--- a/tests/tests/FieldTest.php
+++ b/tests/tests/FieldTest.php
@@ -7,7 +7,7 @@
  * @group   jam
  * @group   jam.field
  */
-class Jam_FieldTest extends PHPUnit_Framework_TestCase {
+class Jam_FieldTest extends PHPUnit_Framework_DOMTestCase {
 
 	/**
 	 * Provider for test_construction

--- a/tests/tests/FormTest.php
+++ b/tests/tests/FormTest.php
@@ -6,7 +6,7 @@
  * @group   jam.form
  * @group   jam.form.core
  */
-class Jam_FormTest extends PHPUnit_Framework_TestCase {
+class Jam_FormTest extends PHPUnit_Framework_DOMTestCase {
 
 	protected $form;
 	protected $post;

--- a/tests/tests/MetaTest.php
+++ b/tests/tests/MetaTest.php
@@ -7,7 +7,7 @@
  * @group   jam
  * @group   jam.meta
  */
-class Jam_MetaTest extends PHPUnit_Framework_TestCase {
+class Jam_MetaTest extends PHPUnit_Framework_DOMTestCase {
 
 	/**
 	 * Tests various properties on a meta object.

--- a/tests/tests/ModelTest.php
+++ b/tests/tests/ModelTest.php
@@ -7,7 +7,7 @@
  * @group   jam
  * @group   jam.model
  */
-class Jam_ModelTest extends PHPUnit_Framework_TestCase {
+class Jam_ModelTest extends PHPUnit_Framework_DOMTestCase {
 
 	/**
 	 * Provider for test_save_empty_model

--- a/tests/tests/RangeTest.php
+++ b/tests/tests/RangeTest.php
@@ -5,7 +5,7 @@
  * @group   jam
  * @group   jam.range
  */
-class Jam_RangeTest extends PHPUnit_Framework_TestCase {
+class Jam_RangeTest extends PHPUnit_Framework_DOMTestCase {
 
 	public function data_construct()
 	{

--- a/tests/tests/SerializeTest.php
+++ b/tests/tests/SerializeTest.php
@@ -5,7 +5,7 @@
  * @group   jam
  * @group   jam.serialize
  */
-class Jam_SerializeTest extends PHPUnit_Framework_TestCase {
+class Jam_SerializeTest extends PHPUnit_Framework_DOMTestCase {
 
 	public function test_collection()
 	{

--- a/tests/tests/TimezoneTest.php
+++ b/tests/tests/TimezoneTest.php
@@ -7,7 +7,7 @@
  * @group   jam
  * @group   jam.timezone
  */
-class Jam_TimezoneTest extends PHPUnit_Framework_TestCase {
+class Jam_TimezoneTest extends PHPUnit_Framework_DOMTestCase {
 
 	public $date;
 	public $timezone;

--- a/tests/tests/array/AssociationTest.php
+++ b/tests/tests/array/AssociationTest.php
@@ -8,7 +8,7 @@
  * @group   jam.array
  * @group   jam.array.association
  */
-class Jam_Array_AssociationTest extends PHPUnit_Framework_TestCase {
+class Jam_Array_AssociationTest extends PHPUnit_Framework_DOMTestCase {
 
 	public $data = array(array('id' => 1, 'name' => 'one'), array('id' => 3, 'name' => 'three'));
 	public $collection;

--- a/tests/tests/array/ModelTest.php
+++ b/tests/tests/array/ModelTest.php
@@ -8,7 +8,7 @@
  * @group   jam.array
  * @group   jam.array.model
  */
-class Jam_Array_ModelTest extends PHPUnit_Framework_TestCase {
+class Jam_Array_ModelTest extends PHPUnit_Framework_DOMTestCase {
 
 	public $data = array(array('id' => 1, 'name' => 'one'), array('id' => 3, 'name' => 'three'));
 	public $collection;

--- a/tests/tests/field/BooleanTest.php
+++ b/tests/tests/field/BooleanTest.php
@@ -8,7 +8,7 @@
  * @group   jam.field
  * @group   jam.field.boolean
  */
-class Jam_Field_BooleanTest extends PHPUnit_Framework_TestCase {
+class Jam_Field_BooleanTest extends PHPUnit_Framework_DOMTestCase {
 
 	/**
 	 * Boolean fields cannot have convert_empty set to TRUE.

--- a/tests/tests/field/DecimalTest.php
+++ b/tests/tests/field/DecimalTest.php
@@ -8,7 +8,7 @@
  * @group   jam.field
  * @group   jam.field.decimal
  */
-class Jam_Field_DecimalTest extends PHPUnit_Framework_TestCase {
+class Jam_Field_DecimalTest extends PHPUnit_Framework_DOMTestCase {
 
 	public function test_set()
 	{

--- a/tests/tests/field/PasswordTest.php
+++ b/tests/tests/field/PasswordTest.php
@@ -8,7 +8,7 @@
  * @group   jam.field
  * @group   jam.field.password
  */
-class Jam_Field_PasswordTest extends PHPUnit_Framework_TestCase {
+class Jam_Field_PasswordTest extends PHPUnit_Framework_DOMTestCase {
 
 	public function data_change_password()
 	{

--- a/tests/tests/field/PrimaryTest.php
+++ b/tests/tests/field/PrimaryTest.php
@@ -8,7 +8,7 @@
  * @group   jam.field
  * @group   jam.field.primary
  */
-class Jam_Field_PrimaryTest extends PHPUnit_Framework_TestCase {
+class Jam_Field_PrimaryTest extends PHPUnit_Framework_DOMTestCase {
 
 	/**
 	 * Primary fields cannot have allow_null set to FALSE.

--- a/tests/tests/field/RangeTest.php
+++ b/tests/tests/field/RangeTest.php
@@ -8,7 +8,7 @@
  * @group   jam.field
  * @group   jam.field.range
  */
-class Jam_Field_RangeTest extends PHPUnit_Framework_TestCase {
+class Jam_Field_RangeTest extends PHPUnit_Framework_DOMTestCase {
 
 	public function test_set()
 	{

--- a/tests/tests/field/TimestampTest.php
+++ b/tests/tests/field/TimestampTest.php
@@ -8,7 +8,7 @@
  * @group   jam.field
  * @group   jam.field.timestamp
  */
-class Jam_Field_TimestampTest extends PHPUnit_Framework_TestCase {
+class Jam_Field_TimestampTest extends PHPUnit_Framework_DOMTestCase {
 
 	/**
 	 * Provider for test_format

--- a/tests/tests/form/GeneralTest.php
+++ b/tests/tests/form/GeneralTest.php
@@ -6,7 +6,7 @@
  * @group   jam.form
  * @group   jam.form.general
  */
-class Jam_Form_GeneralTest extends PHPUnit_Framework_TestCase {
+class Jam_Form_GeneralTest extends PHPUnit_Framework_DOMTestCase {
 
 	protected $form;
 	protected $post;
@@ -62,7 +62,7 @@ class Jam_Form_GeneralTest extends PHPUnit_Framework_TestCase {
 	{
 		$input = $this->form->file('name', array(), array('class' => 'myclass'));
 
-		$this->assertSelectCount('input.myclass[type="file"][name="name"][id="name"][value=""]', 1, $input);
+		$this->assertSelectCount('input.myclass[type="file"][name="name"][id="name"]', 1, $input);
 	}
 
 	public function test_textarea()

--- a/tests/tests/query/BuilderTest.php
+++ b/tests/tests/query/BuilderTest.php
@@ -8,7 +8,7 @@
  * @group   jam.query.builder
  * @group   jam.query.builder.core
  */
-class Jam_Query_BuilderTest extends PHPUnit_Framework_TestCase {
+class Jam_Query_BuilderTest extends PHPUnit_Framework_DOMTestCase {
 
 	public function data_resolve_attribute_name()
 	{

--- a/tests/tests/query/builder/CollectionTest.php
+++ b/tests/tests/query/builder/CollectionTest.php
@@ -8,7 +8,7 @@
  * @group   jam.query.builder
  * @group   jam.query.builder.collection
  */
-class Jam_Query_Builder_CollectionTest extends PHPUnit_Framework_TestCase {
+class Jam_Query_Builder_CollectionTest extends PHPUnit_Framework_DOMTestCase {
 
 	public $collection;
 	public $data;

--- a/tests/tests/query/builder/DeleteTest.php
+++ b/tests/tests/query/builder/DeleteTest.php
@@ -8,7 +8,7 @@
  * @group   jam.query.builder
  * @group   jam.query.builder.delete
  */
-class Jam_Query_Builder_DeleteTest extends PHPUnit_Framework_TestCase {
+class Jam_Query_Builder_DeleteTest extends PHPUnit_Framework_DOMTestCase {
 
 	public function test_constructor()
 	{

--- a/tests/tests/query/builder/InsertTest.php
+++ b/tests/tests/query/builder/InsertTest.php
@@ -8,7 +8,7 @@
  * @group   jam.query.builder
  * @group   jam.query.builder.insert
  */
-class Jam_Query_Builder_InsertTest extends PHPUnit_Framework_TestCase {
+class Jam_Query_Builder_InsertTest extends PHPUnit_Framework_DOMTestCase {
 
 	/**
 	 * @covers Jam_Query_Builder_Insert::__construct

--- a/tests/tests/query/builder/JoinTest.php
+++ b/tests/tests/query/builder/JoinTest.php
@@ -8,7 +8,7 @@
  * @group   jam.query.builder
  * @group   jam.query.builder.join
  */
-class Jam_Query_Builder_JoinTest extends PHPUnit_Framework_TestCase {
+class Jam_Query_Builder_JoinTest extends PHPUnit_Framework_DOMTestCase {
 
 	public function test_compile()
 	{

--- a/tests/tests/query/builder/SelectTest.php
+++ b/tests/tests/query/builder/SelectTest.php
@@ -8,7 +8,7 @@
  * @group   jam.query.builder
  * @group   jam.query.builder.select
  */
-class Jam_Query_Builder_SelectTest extends PHPUnit_Framework_TestCase {
+class Jam_Query_Builder_SelectTest extends PHPUnit_Framework_DOMTestCase {
 
 	public function test_constructor()
 	{

--- a/tests/tests/query/builder/UpdateTest.php
+++ b/tests/tests/query/builder/UpdateTest.php
@@ -8,7 +8,7 @@
  * @group   jam.query.builder
  * @group   jam.query.builder.update
  */
-class Jam_Query_Builder_UpdateTest extends PHPUnit_Framework_TestCase {
+class Jam_Query_Builder_UpdateTest extends PHPUnit_Framework_DOMTestCase {
 
 	public function test_constructor()
 	{


### PR DESCRIPTION
As of PHPUnit 4.2 assertions built-in into PHPUnit about the DOM
are extracted and refactored in https://github.com/phpunit/phpunit-dom-assertions

I've replaced `PHPUnit_Framework_TestCase` with `PHPUnit_Framework_DOMTestCase`.

The one failing test with the new assertions was `Jam_Form_GeneralTest::test_file`.
`[value=""]` no longer matches when the `value` attribute is missing altogether.
