### PR TITLE
Fix find_by_slug return value

### DIFF
--- a/classes/Kohana/Jam/Behavior/Sluggable.php
+++ b/classes/Kohana/Jam/Behavior/Sluggable.php
@@ -205,8 +205,9 @@ class Kohana_Jam_Behavior_Sluggable extends Jam_Behavior {
 	public function builder_call_find_by_slug(Jam_Query_Builder_Select $builder, Jam_Event_Data $data, $slug)
 	{
 		$this->builder_call_where_slug($builder, $data, $slug);
-		$data->return = $builder->first();
+		$result = $builder->first();
 		$data->stop = TRUE;
+		return $data->return = ($result !== NULL) ? $result : FALSE;
 	}
 
 	/**

--- a/classes/Kohana/Jam/Query/Builder/Delete.php
+++ b/classes/Kohana/Jam/Query/Builder/Delete.php
@@ -130,7 +130,7 @@ abstract class Kohana_Jam_Query_Builder_Delete extends Database_Query_Builder_De
 	public function __call($method, $args)
 	{
 		$return = $this->meta()->events()->trigger_callback('builder', $this, $method, $args);
-		return $return ? $return : $this;
+		return ($return !== NULL) ? $return : $this;
 	}
 
 	/**

--- a/classes/Kohana/Jam/Query/Builder/Select.php
+++ b/classes/Kohana/Jam/Query/Builder/Select.php
@@ -244,7 +244,7 @@ abstract class Kohana_Jam_Query_Builder_Select extends Database_Query_Builder_Se
 	public function __call($method, $args)
 	{
 		$return = $this->_meta->events()->trigger_callback('builder', $this, $method, $args);
-		return $return ? $return : $this;
+		return ($return !== NULL) ? $return : $this;
 	}
 
 	/**

--- a/classes/Kohana/Jam/Query/Builder/Update.php
+++ b/classes/Kohana/Jam/Query/Builder/Update.php
@@ -129,7 +129,7 @@ abstract class Kohana_Jam_Query_Builder_Update extends Database_Query_Builder_Up
 	public function __call($method, $args)
 	{
 		$return = $this->_meta->events()->trigger_callback('builder', $this, $method, $args);
-		return $return ? $return : $this;
+		return ($return !== NULL) ? $return : $this;
 	}
 
 	/**


### PR DESCRIPTION
When there are no results, the call to the `first()` method returns NULL,
but this does not get the event system to return the NULL value.

This change makes it so `find_by_slug` will return `FALSE` when there are
no results.

If you have previously checked explicitly for the NULL value, you had been
affected by this bug. This commit does not change that, you are still
affected and you to check for falsy value. Changing the event system to be
able to return NULL instead of chaining and returning the builder object is
not an easy thing and will lead to more BC changes.

If you have previously checked for falsy return value from find_by_slug,
you have been affected by this bug and you will no longer be affected with
this commit.