### PR TITLE
Fix triggering callbacks with upperase letters

### DIFF
--- a/classes/Kohana/Jam/Event.php
+++ b/classes/Kohana/Jam/Event.php
@@ -123,7 +123,7 @@ abstract class Kohana_Jam_Event {
 	 */
 	public function trigger_callback($type, $sender, $method, $params)
 	{
-		$event = "{$type}.call_{$method}";
+		$event = strtolower("{$type}.call_{$method}");
 
 		if (empty($this->_events[$event]))
 			throw new Jam_Exception_Methodmissing($sender, $method, $params);


### PR DESCRIPTION
Jam is lower-casing the names of the methods when discovering events. So when a method is called later through the `__call()` and `trigger_callback()` methods, the method name should be again lower-cased so it could be find in the events map.

This is fixing registering `model_call_` methods with camel case in a behavior.