### PR TITLE
Fix autocreate to search by additional fields as well

### DIFF
--- a/classes/Kohana/Jam/Association/Autocreate.php
+++ b/classes/Kohana/Jam/Association/Autocreate.php
@@ -11,20 +11,41 @@
  */
 abstract class Kohana_Jam_Association_Autocreate extends Jam_Association_Belongsto {
 
-	public $default_fields;
+	/**
+	 * @deprecated Use $additional_fields instead
+	 * Will be removed in 0.6
+	 * @var array
+	 */
+	public $default_fields = array();
+
+	/**
+	 * Additional fields to search for existing entry by.
+	 * They get set if a new entry is autocreated.
+	 * @var array
+	 */
+	public $additional_fields = array();
 
 	public function set(Jam_Validated $model, $value, $is_changed)
 	{
 		if ($is_changed AND $value AND is_string($value) AND ! is_numeric($value))
 		{
-			$value = Jam::find_or_create($this->foreign_model, array(
-				':name_key' => $value
-			));
-
-			if ($this->default_fields)
+			if ($this->default_fields AND ! $this->additional_fields)
 			{
-				$value->set($this->default_fields);
+				$this->additional_fields = $this->default_fields;
 			}
+
+			if (! is_array($this->additional_fields))
+			{
+				$this->additional_fields = array();
+			}
+
+			$value = Jam::find_or_create(
+				$this->foreign_model,
+				array_merge(
+					array(':name_key' => $value),
+					$this->additional_fields
+				)
+			);
 		}
 
 		return parent::set($model, $value, $is_changed);

--- a/tests/tests/association/AutocreateTest.php
+++ b/tests/tests/association/AutocreateTest.php
@@ -43,9 +43,9 @@ class Jam_Association_AutocreateTest extends Testcase_Database {
 	 * @dataProvider data_set
 	 * @covers Jam_Association_Autocreate::set
 	 */
-	public function test_set($value, $default_fields, $expected_value, $expected_foreign_key)
+	public function test_set($value, $additional_fields, $expected_value, $expected_foreign_key)
 	{
-		$association = new Jam_Association_Autocreate(array('default_fields' => $default_fields));
+		$association = new Jam_Association_Autocreate(array('additional_fields' => $additional_fields));
 		$association->initialize($this->meta, 'test_author');
 
 		$model = new Model_Test_Post();


### PR DESCRIPTION
`default_fields` is deprecated in favour of the more accurate `additional_fields`