### PR TITLE
Update default method for range field

### DIFF
--- a/classes/Kohana/Jam/Field/Range.php
+++ b/classes/Kohana/Jam/Field/Range.php
@@ -68,7 +68,7 @@ abstract class Kohana_Jam_Field_Range extends Jam_Field {
 		}
 
 		// Convert empty values to NULL, if needed
-		if ($this->convert_empty AND (empty($min) OR empty($max)))
+		if ($this->convert_empty AND ($min == '' OR $max == ''))
 		{
 			$value  = $this->empty_value;
 			$return = TRUE;

--- a/classes/Kohana/Jam/Field/Range.php
+++ b/classes/Kohana/Jam/Field/Range.php
@@ -43,4 +43,44 @@ abstract class Kohana_Jam_Field_Range extends Jam_Field {
 
 		return $value->__toString();
 	}
+
+	protected function _default(Jam_Validated $model, $value)
+	{
+		$return = FALSE;
+
+		$value = $this->run_filters($model, $value);
+
+		$min = NULL;
+		$max = NULL;
+
+		if (is_array($value))
+		{
+			$min = $value[0];
+			$max = $value[1];
+		}
+
+		if (is_string($value) AND strstr($value, '|'))
+		{
+			$values = explode('|', $value);
+
+			$min = isset($values[0]) ? $values[0] : NULL;
+			$max = isset($values[1]) ? $values[1] : NULL;
+		}
+
+		// Convert empty values to NULL, if needed
+		if ($this->convert_empty AND (empty($min) OR empty($max)))
+		{
+			$value  = $this->empty_value;
+			$return = TRUE;
+		}
+
+		// Allow NULL values to pass through untouched by the field
+		if ($this->allow_null AND ($min === NULL OR $max === NULL))
+		{
+			$value  = NULL;
+			$return = TRUE;
+		}
+
+		return array($value, $return);
+	}
 }

--- a/tests/tests/field/RangeTest.php
+++ b/tests/tests/field/RangeTest.php
@@ -67,4 +67,52 @@ class Jam_Field_RangeTest extends PHPUnit_Framework_DOMTestCase {
 		$this->assertInstanceOf('Jam_Range', $range);
 		$this->assertEquals('10 - 20 days', $range->humanize());
 	}
+
+	public function test_set_empty_value_with_convert_empty()
+	{
+		$field = new Jam_Field_Range(array(
+			'convert_empty' => TRUE
+		));
+
+		$model = Jam::build('test_position');
+
+		$range = $field->set($model, '|', FALSE);
+
+		$this->assertEquals(NULL, $range);
+
+		$range = $field->set($model, '0|0', FALSE);
+
+		$this->assertInstanceOf('Jam_Range', $range);
+		$this->assertEquals(0, $range->min());
+		$this->assertEquals(0, $range->max());
+
+		$range = $field->set($model, array('',''), FALSE);
+
+		$this->assertEquals(NULL, $range);
+	}
+
+	public function test_set_empty_value_without_convert_empty()
+	{
+		$field = new Jam_Field_Range();
+
+		$model = Jam::build('test_position');
+
+		$range = $field->set($model, '|', FALSE);
+
+        $this->assertInstanceOf('Jam_Range', $range);
+        $this->assertEquals(NULL, $range->min());
+        $this->assertEquals(NULL, $range->max());
+
+		$range = $field->set($model, '0|0', FALSE);
+
+		$this->assertInstanceOf('Jam_Range', $range);
+		$this->assertEquals(0, $range->min());
+		$this->assertEquals(0, $range->max());
+
+		$range = $field->set($model, array('',''), FALSE);
+
+        $this->assertInstanceOf('Jam_Range', $range);
+        $this->assertEquals(NULL, $range->min());
+        $this->assertEquals(NULL, $range->max());
+	}
 }


### PR DESCRIPTION
Update `_default` method for range field to support `NULL` as value.