### PR TITLE
Fix php warning for combining numeric and non-numeric values.

### DIFF
--- a/classes/Kohana/Jam/Range.php
+++ b/classes/Kohana/Jam/Range.php
@@ -34,8 +34,13 @@ class Kohana_Jam_Range implements ArrayAccess, Serializable {
 
 		foreach ($ranges as $range)
 		{
-			$min += $range->min();
-			$max += $range->max();
+			if (!empty($range->min())) {
+				$min += $range->min();
+			}
+
+			if (!empty($range->min())) {
+				$max += $range->min();
+			}
 		}
 
 		return new Jam_Range(array($min, $max), $format);

--- a/classes/Kohana/Jam/Range.php
+++ b/classes/Kohana/Jam/Range.php
@@ -34,13 +34,8 @@ class Kohana_Jam_Range implements ArrayAccess, Serializable {
 
 		foreach ($ranges as $range)
 		{
-			if (!empty($range->min())) {
-				$min += $range->min();
-			}
-
-			if (!empty($range->min())) {
-				$max += $range->min();
-			}
+			$min += (int) $range->min();
+			$max += (int) $range->max();
 		}
 
 		return new Jam_Range(array($min, $max), $format);


### PR DESCRIPTION
Avoid warning for mixing php numeric and non-numeric values.