### PR TITLE
Fixed collection validation loop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: php
 sudo: false
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ Support
 
 Supports the following PHP versions:
 
-- PHP 5.3
 - PHP 5.4
 - PHP 5.5
 - PHP 5.6

--- a/classes/Kohana/Jam/Array/Model.php
+++ b/classes/Kohana/Jam/Array/Model.php
@@ -363,7 +363,7 @@ abstract class Kohana_Jam_Array_Model extends Jam_Array {
 		foreach ($this->_changed as $offset => $is_changed)
 		{
 			$item = $this->offsetGet($offset);
-			if ($is_changed AND $item AND ! $item->check())
+			if ($is_changed AND $item AND ! $item->is_validating() AND ! $item->check())
 			{
 				$check = FALSE;
 			}

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		}
 	],
 	"require": {
-		"php": ">=5.3.9",
+		"php": ">=5.4",
 		"composer/installers": "*",
 		"kohana/core": "^3.3.0",
 		"kohana/database": "^3.3.0",


### PR DESCRIPTION
When checking has many associations the `is_validating` flag was not being checked which resulted in an endless loop in some cases.