### PR TITLE
Add Null coalescing (??) operator passing arr arg to load_item

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,8 @@ notifications:
 services:
   - mysql
 
-before_install: composer selfupdate --preview
+before_install:
+  - composer self-update --1
 
 install:
   - if [ "$DEPS" = "normal" ]; then composer install --no-interaction; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ env:
   - DEPS=normal
   - DEPS=highest
   - DEPS=lowest
-  - XDEBUG_MODE=coverage
 
 matrix:
   fast_finish: true
@@ -47,7 +46,7 @@ before_script:
   - mysql openbuildings/jam < tests/database/structure/mysql.sql
 
 script:
-  - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+  - XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-clover build/logs/clover.xml
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   - DEPS=normal
   - DEPS=highest
   - DEPS=lowest
+  - XDEBUG_MODE=coverage
 
 matrix:
   fast_finish: true

--- a/classes/Kohana/Jam/Array.php
+++ b/classes/Kohana/Jam/Array.php
@@ -133,7 +133,7 @@ abstract class Kohana_Jam_Array implements Countable, ArrayAccess, Iterator, Ser
 		if (is_array($this->_content) AND ! array_key_exists($offset, $this->_content))
 			return NULL;
 
-		return $this->_load_item($this->_content[$offset], isset($this->_changed[$offset]), $offset);
+		return $this->_load_item($this->_content[$offset] ?? null, isset($this->_changed[$offset]), $offset);
 	}
 
 	/**
@@ -202,7 +202,7 @@ abstract class Kohana_Jam_Array implements Countable, ArrayAccess, Iterator, Ser
 		if ( ! $this->valid())
 			return NULL;
 
-		return $this->_load_item($this->_content[$this->_current], isset($this->_changed[$this->_current]), $this->_current);
+		return $this->_load_item($this->_content[$this->_current] ?? null, isset($this->_changed[$this->_current]), $this->_current);
 	}
 
 	/**


### PR DESCRIPTION
**Why this is here?**

When we are using the [jam](https://github.com/OpenBuildings/jam) with PHP 7.3 and if `$this->_content` is `null` following:
```
$this->_content[$offset]
```
[here](https://github.com/OpenBuildings/jam/blob/master/classes/Kohana/Jam/Array.php#L136) and [there](https://github.com/OpenBuildings/jam/blob/master/classes/Kohana/Jam/Array.php#L205) works without warnings.


From PHP 7.4 when you try to do it you will have a `Notice`. The following example is with PHP 7.4.13:
```
$ php -a
Interactive mode enabled

php > $foo=null;
php > $foo['bar'];
PHP Notice:  Trying to access array offset on value of type null in php shell code on line 1
PHP Stack trace:
PHP   1. {main}() php shell code:0
```

To avoid the `Notice` I added the checks in this PR.
```
php > $foo['bar']??null;
php >
``` 